### PR TITLE
Fix race conditions

### DIFF
--- a/src/chan_test.c
+++ b/src/chan_test.c
@@ -8,10 +8,6 @@
 
 #include "chan.h"
 
-#ifdef _WIN32
-#include <windows.h>
-#define sleep(x) Sleep(x)
-#endif
 
 int passed = 0;
 
@@ -30,6 +26,30 @@ void pass()
     printf(".");
     fflush(stdout);
     passed++;
+}
+
+void wait_for_reader(chan_t* chan)
+{
+    for (;;)
+    {
+        pthread_mutex_lock(&chan->m_mu);
+        int send = chan->r_waiting > 0;
+        pthread_mutex_unlock(&chan->m_mu);
+        if (send) break;
+        sched_yield();
+    }
+}
+
+void wait_for_writer(chan_t* chan)
+{
+    for (;;)
+    {
+        pthread_mutex_lock(&chan->m_mu);
+        int recv = chan->w_waiting > 0;
+        pthread_mutex_unlock(&chan->m_mu);
+        if (recv) break;
+        sched_yield();
+    }
 }
 
 void test_chan_init_buffered()
@@ -104,15 +124,7 @@ void test_chan_send_unbuffered()
     pthread_t th;
     pthread_create(&th, NULL, receiver, chan);
 
-    // Wait for reader
-    for (;;)
-    {
-        pthread_mutex_lock(&chan->m_mu);
-        int send = chan->r_waiting > 0;
-        pthread_mutex_unlock(&chan->m_mu);
-        if (send) break;
-        sched_yield();
-    }
+    wait_for_reader(chan);
 
     assert_true(chan_size(chan) == 0, chan, "Chan size is not 0");
     assert_true(!chan->w_waiting, chan, "Chan has sender");
@@ -215,7 +227,7 @@ void test_chan_select_recv()
 
     pthread_t th;
     pthread_create(&th, NULL, sender, chan1);
-    sleep(1);
+    wait_for_writer(chan1);
 
     switch(chan_select(chans, 2, &recv, NULL, 0, NULL))
     {
@@ -295,7 +307,7 @@ void test_chan_select_send()
 
     pthread_t th;
     pthread_create(&th, NULL, receiver, chan1);
-    sleep(1);
+    wait_for_reader(chan1);
 
     switch(chan_select(NULL, 0, NULL, chans, 2, msg))
     {


### PR DESCRIPTION
Replace `sleep(1)` in unit tests with `wait_for_reader` and `wait_for_writer`.
