### PR TITLE
remove chan_test.o from static library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 
 PREFIX ?= /usr/local
 
-SRCS += $(wildcard $(SRC)/*.c)
+SRCS += $(filter-out $(SRC)/chan_test.c, $(wildcard $(SRC)/*.c))
 
 OBJS += $(SRCS:.c=.o)
 


### PR DESCRIPTION
Remove the chan_test.c from the SRS, or the main function redefined in chan_test.o may cause an compile error.
