### PR TITLE
Fix race condition allowing duplicate unbuffered reads

### DIFF
--- a/src/chan.c
+++ b/src/chan.c
@@ -321,7 +321,6 @@ static int unbuffered_chan_send(chan_t* chan, void* data)
 
     // Block until reader consumed chan->data.
     pthread_cond_wait(&chan->w_cond, &chan->m_mu);
-    chan->w_waiting--;
 
     pthread_mutex_unlock(&chan->m_mu);
     pthread_mutex_unlock(&chan->w_mu);
@@ -353,6 +352,7 @@ static int unbuffered_chan_recv(chan_t* chan, void** data)
     {
         *data = chan->data;
     }
+    chan->w_waiting--;
 
     // Signal waiting writer.
     pthread_cond_signal(&chan->w_cond);


### PR DESCRIPTION
Previously, this sequence of events would result in the same
value being read twice from an unbuffered channel:

    Thread S                     Thread R
    --------                     --------
    unbuffered_chan_send()
      chan->data = data
      chan->w_waiting++
      cond_wait on chan->m_mu
                                 unbuffered_chan_recv()
                                   mutex_lock chan->m_mu
                                   chan->w_waiting > 0
                                   *data = chan->data
                                   cond_signal chan->w_cond
                                   mutex_unlock chan->m_mu

                                 unbuffered_chan_recv()
                                   mutex_lock chan->m_mu
                                   chan->w_waiting > 0
                                   *data = chan->data
                                   cond_signal chan->w_cond
                                   mutex_unlock chan->m_mu
      chan->w_waiting--
      mutex_unlock chan->m_mu

Moving the `chan->w_waiting--` to immediately after the data
is read in `unbuffered_chan_recv()` prevents this double read.

Fixes #23