### PR TITLE
Fix minor build warnings in examples when built with -Wall

### DIFF
--- a/examples/buffered.c
+++ b/examples/buffered.c
@@ -13,10 +13,10 @@ int main()
     // Later receive the values.
     void* msg;
     chan_recv(chan, &msg);
-    printf("%s\n", msg);
+    printf("%s\n", (char *)msg);
 
     chan_recv(chan, &msg);
-    printf("%s\n", msg);
+    printf("%s\n", (char *)msg);
 
     // Clean up channel.
     chan_dispose(chan);

--- a/examples/close.c
+++ b/examples/close.c
@@ -12,7 +12,7 @@ void* worker()
     void* job;
     while (chan_recv(jobs, &job) == 0)
     {
-        printf("received job %d\n", (int) job);
+        printf("received job %ld\n", (long) job);
     }
 
     // Notify that all jobs were received.

--- a/examples/select.c
+++ b/examples/select.c
@@ -17,7 +17,7 @@ int main()
     switch(chan_select(&messages, 1, &msg, NULL, 0, NULL))
     {
         case 0:
-            printf("received message %s\n", msg);
+            printf("received message %s\n", (char *)msg);
             break;
         default:
             printf("no message received\n");
@@ -28,7 +28,7 @@ int main()
     switch(chan_select(NULL, 0, NULL, &messages, 1, &msg))
     {
         case 0:
-            printf("sent message %s\n", msg);
+            printf("sent message %s\n", (char *)msg);
             break;
         default:
             printf("no message sent\n");
@@ -41,10 +41,10 @@ int main()
     switch(chan_select(chans, 2, &msg, NULL, 0, NULL))
     {
         case 0:
-            printf("received message %s\n", msg);
+            printf("received message %s\n", (char *)msg);
             break;
         case 1:
-            printf("received signal %s\n", msg);
+            printf("received signal %s\n", (char *)msg);
             break;
         default:
             printf("no activity\n");

--- a/examples/unbuffered.c
+++ b/examples/unbuffered.c
@@ -22,7 +22,7 @@ int main()
     // Receive blocks until sender is ready.
     void* msg;
     chan_recv(chan, &msg);
-    printf("%s\n", msg);
+    printf("%s\n", (char *)msg);
 
     // Clean up channel.
     chan_dispose(chan);


### PR DESCRIPTION
Fix minor warnings from RPM build, which uses -Wall.